### PR TITLE
feat(tests): add e2e scenarios for post CRUD operations  

### DIFF
--- a/src/test/java/posts/PostsRunner.java
+++ b/src/test/java/posts/PostsRunner.java
@@ -16,10 +16,15 @@ public class PostsRunner {
     @Karate.Test
     Karate testPostPosts() {
         return Karate.run("update-posts").tags("@UpdatePosts").relativeTo(getClass());
-    }*/
+    }
     @Karate.Test
     Karate testPostPosts() {
         return Karate.run("delete-posts").tags("@DeletePosts").relativeTo(getClass());
+    }*/
+
+    @Karate.Test
+    Karate testPostPosts() {
+        return Karate.run("end-to-end").tags("@E2E").relativeTo(getClass());
     }
 
-}
+    }

--- a/src/test/java/posts/PostsRunner.java
+++ b/src/test/java/posts/PostsRunner.java
@@ -3,7 +3,7 @@ package posts;
 import com.intuit.karate.junit5.Karate;
 
 public class PostsRunner {
-    /*@Karate.Test
+    @Karate.Test
     Karate testGetPosts() {
         return Karate.run("get-posts").tags("@GetPosts").relativeTo(getClass());
     }
@@ -14,16 +14,16 @@ public class PostsRunner {
     }
 
     @Karate.Test
-    Karate testPostPosts() {
+    Karate testUpdatePosts() {
         return Karate.run("update-posts").tags("@UpdatePosts").relativeTo(getClass());
     }
     @Karate.Test
-    Karate testPostPosts() {
+    Karate testDeletePosts() {
         return Karate.run("delete-posts").tags("@DeletePosts").relativeTo(getClass());
-    }*/
+    }
 
     @Karate.Test
-    Karate testPostPosts() {
+    Karate testE2E() {
         return Karate.run("end-to-end").tags("@E2E").relativeTo(getClass());
     }
 

--- a/src/test/java/posts/end-to-end.feature
+++ b/src/test/java/posts/end-to-end.feature
@@ -1,0 +1,5 @@
+@E2E
+Feature: End-to-End Scenarios for JSONPlaceholder API
+
+  Background:
+    Given url baseUrl + '/posts'

--- a/src/test/java/posts/end-to-end.feature
+++ b/src/test/java/posts/end-to-end.feature
@@ -3,3 +3,59 @@ Feature: End-to-End Scenarios for JSONPlaceholder API
 
   Background:
     Given url baseUrl + '/posts'
+
+  Scenario: Create a new post, update it, and then delete it
+    When request { title: 'New Post', body: 'This is a new post', userId: 1 }
+    And method post
+    Then status 201
+    And match response == { title: 'New Post', body: 'This is a new post', userId: 1, id: '#ignore' }
+    * def createdPostId = response.id
+
+    Given path createdPostId
+    And request { id: createdPostId, title: 'Updated Post', body: 'This is an updated post', userId: 1 }
+    When method put
+    Then status 200
+    And match response == { id: createdPostId, title: 'Updated Post', body: 'This is an updated post', userId: 1 }
+
+    Given path createdPostId
+    When method delete
+    Then status 200
+
+    Given path createdPostId
+    When method get
+    Then status 404
+    And match response == {}
+
+  Scenario: Create multiple posts, retrieve them, and then delete them
+    When request { title: 'Post 1', body: 'First post', userId: 1 }
+    And method post
+    Then status 201
+    * def postId1 = response.id
+
+    When request { title: 'Post 2', body: 'Second post', userId: 1 }
+    And method post
+    Then status 201
+    * def postId2 = response.id
+
+    Given url baseUrl + '/posts'
+    When method get
+    Then status 200
+    And assert parseInt(response.length) > 100
+    And match response contains { id: postId1, title: 'Post 1', userId: 1 }
+    And match response contains { id: postId2, title: 'Post 2', userId: 1 }
+
+    Given path postId1
+    When method delete
+    Then status 200
+
+    Given path postId2
+    When method delete
+    Then status 200
+
+    Given path postId1
+    When method get
+    Then status 404
+
+    Given path postId2
+    When method get
+    Then status 404


### PR DESCRIPTION
- Created a new end-to-end (e2e) feature 
- Integrated e2e tests into the posts runner
- Created the following end-to-end (e2e) scenarios:   
- Create a new post, update it, and then delete it.   
- Create multiple posts, retrieve them, and then delete them.